### PR TITLE
上限単位数を修正

### DIFF
--- a/docs/rule_definitions.json
+++ b/docs/rule_definitions.json
@@ -952,7 +952,7 @@
         {
           "description": "4単位まで",
           "type": "important_subjects_limit",
-          "minimum": 1,
+          "minimum": 4,
           "subjects": [
             "#OTHER_SUBJECTS"
           ]

--- a/src/main/resources/rule_definitions.json
+++ b/src/main/resources/rule_definitions.json
@@ -952,7 +952,7 @@
         {
           "description": "4単位まで",
           "type": "important_subjects_limit",
-          "minimum": 1,
+          "minimum": 4,
           "subjects": [
             "#OTHER_SUBJECTS"
           ]


### PR DESCRIPTION
工学システム学類の、その他の科目の重点科目上限単位数が、descriptionでは4単位までになっているのに、minimumの数値が1になっていたので修正しました。