### PR TITLE
複数の授業を読み込めない問題を修正

### DIFF
--- a/src/main/MigrationChecker.tsx
+++ b/src/main/MigrationChecker.tsx
@@ -219,7 +219,7 @@ const MigrationChecker: React.FC = () => {
     }
 
     const loadCSV = (csvText: string): [Array<UserSubject>, number, string] => {
-        const csv = csvText.replace("\nシラバスシラバス（ミラー）", "")
+        const csv = csvText.replace(/\nシラバスシラバス（ミラー）/g, "")
 
         const userSubjects: Array<UserSubject> = [];
         const split = csv.split("\n");


### PR DESCRIPTION
JavaScriptのreplaceは全部を置換してくれないので、複数の授業のCSVが与えられたときに正しく表示出来ない問題があったので、全部置換するように修正しました